### PR TITLE
Used FromBody attribute to bind model (issue #13)

### DIFF
--- a/src/Controllers/People.cs
+++ b/src/Controllers/People.cs
@@ -39,11 +39,10 @@ namespace WebApplication.Controllers
 
         [Route("api/persons")]
         [AcceptVerbs("POST", "PUT")]
-        public ActionResult AddPerson(string person)/*[FromBody] Person person)*//*string person*/
+        public ActionResult AddPerson([FromBody] Person person)
         {
-            Console.WriteLine("New Person:" + person);
-
-            return Ok(People[0]);
+            Console.WriteLine($"New Person: {person.Name}");
+            return Ok(person);
         }
     }
 }


### PR DESCRIPTION
So, the conjecture in the bottom of issue #13 was a correct one: you should just use the [FromBody] attribute to convince ASP.NET Core to bind json to the model.

It is described in more details in [this article](http://andrewlock.net/model-binding-json-posts-in-asp-net-core/), but it really is all we need.