### PR TITLE
Issue #25: task-solving api

### DIFF
--- a/docs/json/examples/engine-pressure/in.json
+++ b/docs/json/examples/engine-pressure/in.json
@@ -1,0 +1,4 @@
+{
+    "temperature" : 80,
+    "fuel_consumption" : 3.5
+}

--- a/docs/json/examples/engine-pressure/task.json
+++ b/docs/json/examples/engine-pressure/task.json
@@ -1,0 +1,157 @@
+{
+    "name" : "engine_pressure",
+    "in_vars" : [
+        {
+            "name" : "temperature",
+            "from" : 0,
+            "to" : 175,
+            "classes" : [
+                {
+                    "name" : "low",
+                    "type" : "trapezoidal",
+                    "params" : {
+                        "a" : -1,
+                        "b" : 0,
+                        "c" : 50,
+                        "d" : 100
+                    }
+                },
+                {
+                    "name" : "middle",
+                    "type" : "trapezoidal",
+                    "params" : {
+                        "a" : 25,
+                        "b" : 75,
+                        "c" : 125,
+                        "d" : 175
+                    }
+                },
+                {
+                    "name" : "high",
+                    "type" : "trapezoidal",
+                    "params" : {
+                        "a" : 75,
+                        "b" : 150,
+                        "c" : 175,
+                        "d" : 176
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "fuel_consumption",
+            "from" : 0,
+            "to" : 8,
+            "classes" : [
+                {
+                    "name" : "low",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : 0,
+                        "b" : 2,
+                        "c" : 4
+                    }
+                },
+                {
+                    "name" : "middle",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : 2,
+                        "b" : 4,
+                        "c" : 6
+                    }
+                },
+                {
+                    "name" : "high",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : 4,
+                        "b" : 6,
+                        "c" : 8
+                    }
+                }
+            ]
+        }
+    ], 
+    "out_vars" : [
+        {
+            "name" : "pressure",
+            "from" : 0,
+            "to" : 150,
+            "classes" : [
+                {
+                    "name" : "low",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : -1,
+                        "b" : 0,
+                        "c" : 100
+                    }
+                },
+                {
+                    "name" : "middle",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : 50,
+                        "b" : 100,
+                        "c" : 150
+                    }
+                },
+                {
+                    "name" : "high",
+                    "type" : "triangular",
+                    "params" : {
+                        "a" : 100,
+                        "b" : 150,
+                        "c" : 151
+                    }
+                }
+            ]
+        }
+    ],
+    "rules" : [
+        {
+            "var_name" : "pressure",
+            "class_name" : "low",
+            "expr" : {
+                "type" : "and",
+                "left" : {
+                    "type" : "state",
+                    "var_name" : "temperature",
+                    "class_name" : "low"
+                },
+                "right" : {
+                    "type" : "state",
+                    "var_name" : "fuel_consumption",
+                    "class_name" : "low"
+                }
+            }
+        },
+        {
+            "var_name" : "pressure",
+            "class_name" : "middle",
+            "expr" : {
+                "type" : "state",
+                "var_name" : "temperature",
+                "class_name" : "middle"
+            }
+        },
+        {
+            "var_name" : "pressure",
+            "class_name" : "high",
+            "expr" : {
+                "type" : "or",
+                "left" : {
+                    "type" : "state",
+                    "var_name" : "temperature",
+                    "class_name" : "high"
+                },
+                "right" : {
+                    "type" : "state",
+                    "var_name" : "fuel_consumption",
+                    "class_name" : "high"
+                }
+            }
+        }
+    ]
+}

--- a/docs/json/task-format.md
+++ b/docs/json/task-format.md
@@ -1,0 +1,224 @@
+## Storing tasks in JSON format
+
+The program's JsonParser module is capable of storing tasks
+(i.e. objects of `CoreLogic.Task`) as JSON-objects.
+The current document describes the format of these JSON-objects,
+as it is believed to be (at least roughly) readable and editable by humans.
+
+### CoreLogic.Task
+
+Any task is described by:
+- its name;
+- a set of input variables;
+- a set of output variables;
+- a set of rules.
+
+So, the JSON-representation of a task looks like this:
+```
+{
+  "name": <string>,
+  "in_vars": [
+    <varibale>, ...
+  ],
+  "out_vars": [
+    <varibale>, ...
+  ],
+  "rules": [
+    <rule>, ...
+  ],
+}
+```
+Where
+- `<string>` is a simple string in JSON format;
+- `<variable>` is a JSON-representation of a `CoreLogic.Parameter` object as it is described below;
+- `<rule>` is a JSON-representation of a `CoreLogic.Rule` object as it is described below.
+
+### CoreLogic.Parameter
+
+Every variable - input or output one - is described by:
+- its name;
+- its domain range;
+- a set of classes (fuzzy-sets).
+
+As simple as in previous case, the JSON representation of a variable looks like this:
+```
+{
+  "name": <string>,
+  "from": <float>,
+  "to": <float>,
+  "classes": [
+    <class>, ...
+  ]
+}
+```
+
+Where
+- `<string>` is a simple string in JSON format;
+- `<float>` is a floating point number in JSON format;
+- `<class>` is a JSON-representation of any object derived from `CoreLogic.Classes.Class` as it is described below.
+
+Note that, though CoreLogic library uses class `CoreLogic.Range` to represent variable's range,
+the JSON-representation stores its two fields directly in the variable
+and does not describe `CoreLogic.Range` at all.
+
+Also note that the names of input and output variables should be unique
+(but an input variable may have the same name as an output variable).
+
+### CoreLogic.Classes.Class
+
+In CoreLogic library, `CoreLogic.Classes.Class` is an abstract class, that has these concrete heirs:
+- `CoreLogic.Classes.ClassWithTriangularMF`;
+- `CoreLogic.Classes.ClassWithTrapezoidalMF`;
+- `CoreLogic.Classes.ClassWithGaussianMF`;
+- `CoreLogic.Classes.ClassWithGeneralisedBellMF`;
+- `CoreLogic.Classes.ClassWithSigmoidDifferenceMF`.
+
+On contrary, to describe any class in JSON format we only
+use one template that looks like this:
+```
+{
+  "name": <string>,
+  "type": <string>,
+  "params": {
+    /* type-specific parameters */
+  }
+}
+```
+Here `"name"` is, as usually, just a string in JSON format.
+Every class has a name (this is actually `CoreLogic.Classes.Class`'s field),
+so this field does not depend on type of the described class.
+Note that a class's name should be unique within the classes of the variable
+it is tied to (i.e. if a variable has a class named "low-values", it cannot have
+another class with the same name, but any other variable can).
+
+The `"type"` field is used to distinguish the type of the class
+and can only be one of these strings:
+- `"triangular"`;
+- `"trapezoidal"`;
+- `"gaussian"`;
+- `"generalised_bell"`;
+- `"sigmoid_diff"`.
+
+Naturally, the parsing will fail, should this field contain any other value.
+
+As the description notes, the `"params"` dictionary contains the type-specific parameters.
+Here are the forms this dictionary should take, depending on `"type"`'s value:
+- for the `"triangular"` type the dictionary should look like this:
+```
+{
+  "a": <float>,
+  "b": <float>,
+  "c": <float>
+}
+```
+- for the `"trapezoidal"` type the dictionary should look like this:
+```
+{
+  "a": <float>,
+  "b": <float>,
+  "c": <float>,
+  "d": <float>
+}
+```
+- for the `"gaussian"` type the dictionary should look like this:
+```
+{
+  "c": <float>,
+  "sigma": <float>
+}
+```
+- for the `"generalised_bell"` type the dictionary should look like this:
+```
+{
+  "a": <float>,
+  "b": <float>,
+  "c": <float>
+}
+```
+- for the `"sigmoid_diff"` type the dictionary should look like this:
+```
+{
+  "a1": <float>,
+  "a2": <float>,
+  "c1": <float>,
+  "c2": <float>
+}
+```
+
+Where `<float>` is a floating point number in JSON format.
+
+The parsing will fail if the program is not able to find the required keys in the
+dictionary. It will not fail if the dictionary contains any other keys, though.
+
+### CoreLogic.Rule
+
+Rules describe the connection between the input  variables and the output variables.
+What a rule generally says is that an output variable's value lies in one of its classes
+if some subset of input variables lies in some of their classes.
+
+Thus, a rule consists of:
+- a reference to the target output variable
+- a reference to the target output variable's class
+- an expression, describing the fuzzy set of allowed input variables' values
+
+In JSON format this simply looks like:
+```
+{
+  "var_name": <string>,
+  "class_name": <string>,
+  "expr": <expression>
+}
+```
+Where
+- `<string>` is a simple string in JSON format;
+- `<expression>` is a JSON-representation of any object derived from
+  `CoreLogic.Expressions.Expression` as it is described below.
+
+Note that `"var_name"` should be one of the input variables' names
+and `"class_name"` should be one of this variable's classes' names.
+
+### CoreLogic.Expressions.Expression
+
+In CoreLogic library, `CoreLogic.Expressions.Expression` is an abstract class,
+that has these concrete heirs:
+- `CoreLogic.Expressions.Negation`;
+- `CoreLogic.Expressions.Disjunction`;
+- `CoreLogic.Expressions.Conjunction`;
+- `CoreLogic.Expressions.MembershipStatement`.
+
+To describe any expression in JSON format we only use one template, that looks like this:
+```
+{
+  "type": <string>,
+  "var_name": <string>,
+  "class_name": <string>,
+  "arg": <expression>,
+  "left": <expression>,
+  "right": <expression>
+}
+```
+Where
+- `<string>` is a simple string in JSON format;
+- `<expression>` is a JSON-representation of any object derived from
+  `CoreLogic.Expressions.Expression` as it is described in this very section.
+
+The `"type"` field can only contain one of the following strings:
+- `"neg"` to represent `CoreLogic.Expressions.Negation`;
+- `"or"` to represent `CoreLogic.Expressions.Disjunction`;
+- `"and"` to represent `CoreLogic.Expressions.Conjunction`;
+- `"state"` to represent `CoreLogic.Expressions.MembershipStatement`;
+
+Any other value in this field will produce a parsing error.
+
+Each expression type will need some of the other described fields,
+but no type will need all of them, so you can safely omit the ones you don't need.
+
+Here are the fields essential for different kinds of expressions:
+- _negation_ expressions will need a value in `"arg"` field;
+- _conjunction_ and _disjunction_ expressions will need some values in
+  `"left"` and `"right"` fields;
+- _statement_ expressions will need some values in `"var_name"` and `"class_name"` fields.
+
+Statement expressions are used to state that an input variable's value
+lies in one of this variable's class, so `"var_name"` and `"class_name"` field
+should be an input variable's name and a name of one of its classes respectively.

--- a/docs/json/task-in-out-format.md
+++ b/docs/json/task-in-out-format.md
@@ -1,0 +1,44 @@
+## Storing tasks's inputs and outputs in JSON format
+
+The program's JsonParser module is capable of storing tasks' inputs
+and outputs as JSON-objects.
+
+In CoreLogic library, to acquire a solution for a task, you should
+provide it with an instance of `IDictionary<Parameter,double>`,
+that ties every input variable of the task to its value.
+
+JSON-representation of it is simply:
+```
+{
+  <string>: <float>,
+  ...
+}
+```
+Where
+- `<string>` is a simple string in JSON format;
+- `<float>` is a floating point number in JSON format.
+
+The set of the dictionary's keys should include the names of all of the
+target task's input variables. Should it not be the case, a parsing error
+will be produced.
+
+The task's solution is acquired in the form of `IEnumerable<Task.OutputParameterSolution>`.
+`Task.OutputParameterSolution` stores a value distribution for an output variable
+and allows to calcualte its gravity center.
+
+The JSON-representation of the solution does not preserve the variables' value
+distribution functions, storing only their gravity centers.
+
+It is simply:
+```
+{
+  <string>: <float>,
+  ...
+}
+```
+Where
+- `<string>` is a simple string in JSON format;
+- `<float>` is a floating point number in JSON format.
+
+Each of the dictionary's keys is a name of the target task's output variable,
+and the key's value is this variable's value distribution function's gravity center.

--- a/src/Controllers/TaskController.cs
+++ b/src/Controllers/TaskController.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Libraries.FuzzyLogicInference;
+using Libraries.JsonParser;
+
+namespace WebApplication.Controllers
+{
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true, Duration = -1)]
+    public class TaskController : Controller
+    {
+        private readonly double DEFAULT_GRAPHING_STEP = 0.05;
+
+        [Route("api/task/solve")]
+        [AcceptVerbs("POST")]
+        public ActionResult Solve([FromBody] Libraries.JsonParser.Models.Task taskModel)
+        {
+            var task = Parser.TaskFromModel(taskModel);
+            var inputs = task.InputParameters
+                .ToDictionary(
+                    inVar => inVar,
+                    inVar => taskModel.in_vars
+                                .First(inVarModel => inVarModel.name == inVar.Name)
+                                .value
+                );
+
+            var solution = task.Solve(inputs);
+            var solutionModel = Parser.SolutionToModel(solution, DEFAULT_GRAPHING_STEP);
+            
+            return Ok(solutionModel);
+        }
+    }
+}

--- a/src/Controllers/TaskController.cs
+++ b/src/Controllers/TaskController.cs
@@ -10,7 +10,7 @@ namespace WebApplication.Controllers
     [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true, Duration = -1)]
     public class TaskController : Controller
     {
-        private readonly double DEFAULT_GRAPHING_STEP = 0.05;
+        private readonly int DEFAULT_NUMBER_OF_GRAPH_POINTS = 300;
 
         [Route("api/task/solve")]
         [AcceptVerbs("POST")]
@@ -26,7 +26,7 @@ namespace WebApplication.Controllers
                 );
 
             var solution = task.Solve(inputs);
-            var solutionModel = Parser.SolutionToModel(solution, DEFAULT_GRAPHING_STEP);
+            var solutionModel = Parser.SolutionToModel(solution, DEFAULT_NUMBER_OF_GRAPH_POINTS);
             
             return Ok(solutionModel);
         }

--- a/src/Libraries/FuzzyLogicInference/Range.cs
+++ b/src/Libraries/FuzzyLogicInference/Range.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Libraries.FuzzyLogicInference
 {
@@ -41,6 +42,19 @@ namespace Libraries.FuzzyLogicInference
         /// <param name="x"> The value to be tested. </param>
         /// <returns> True if x is in range and false otherwise. </returns>
         public bool Contains(double x) => LowerBoundary <= x && x <= UpperBoundary;
+
+        /// <summary>
+        /// Allows to enumerate throught the range with the given step.
+        /// </summary>
+        /// <param name="step"> The step of enumeration. </param>
+        /// <returns> Returns sequence of numbers x_n = LowerBoundary + n*step, where all x_n <= b. </returns>
+        public IEnumerable<double> EnumerateWithStep(double step)
+        {
+            for (double x = this.LowerBoundary; x <= this.UpperBoundary; x += step)
+            {
+                yield return x;
+            }
+        }
     }
 }
 

--- a/src/Libraries/FuzzyLogicInference/Range.cs
+++ b/src/Libraries/FuzzyLogicInference/Range.cs
@@ -27,6 +27,12 @@ namespace Libraries.FuzzyLogicInference
         public bool IsEmpty { get { return LowerBoundary > UpperBoundary; } }
 
         /// <summary>
+        /// The length of the range.
+        /// </summary>
+        /// <returns> Returns the length of the range. </returns>
+        public double Length { get { return Math.Max(UpperBoundary - LowerBoundary, 0); } }
+
+        /// <summary>
         /// Constructs the range representation.
         /// </summary>
         /// <param name="from"> The lower boundary of the range. </param>

--- a/src/Libraries/JsonParser/JsonParser.cs
+++ b/src/Libraries/JsonParser/JsonParser.cs
@@ -56,6 +56,19 @@ namespace Libraries.JsonParser
 
         public static IDictionary<string, Models.OutputParameterSolution> SolutionToModel(
             IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> solution,
+            int numberOfGraphPoints)
+        {
+            return solution.ToDictionary(
+                s => s.Parameter.Name,
+                s => new Models.OutputParameterSolution {
+                        gravity_center = s.GravityCenter,
+                        graph = BuildGraph(s, s.Parameter.Range.Length / numberOfGraphPoints)
+                    }
+            );
+        }
+
+        public static IDictionary<string, Models.OutputParameterSolution> SolutionToModel(
+            IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> solution,
             double graphingStep)
         {
             return solution.ToDictionary(

--- a/src/Libraries/JsonParser/JsonParser.cs
+++ b/src/Libraries/JsonParser/JsonParser.cs
@@ -10,26 +10,34 @@ namespace Libraries.JsonParser
         public static FuzzyLogicInference.Task TaskFromJson(string json)
         {
             var taskModel = JsonConvert.DeserializeObject<Models.Task>(json);
-
+            return TaskFromModel(taskModel);
+        }
+        
+        public static FuzzyLogicInference.Task TaskFromModel(Models.Task taskModel)
+        {
             var inVars = taskModel.in_vars.Select(ConvertModelToParameter).ToList();
             var outVars = taskModel.out_vars.Select(ConvertModelToParameter).ToList();
             var rules = taskModel.rules.Select(rule => ConvertModelToRule(rule, inVars, outVars)).ToList();
 
             return new FuzzyLogicInference.Task(taskModel.name, inVars, outVars, rules);
         }
-        
+
         public static string TaskToJson(FuzzyLogicInference.Task task) => TaskToJson(task, true);
 
         public static string TaskToJson(FuzzyLogicInference.Task task, bool indentSubobjects)
         {
-            var taskModel = new Models.Task {
+            var taskModel = TaskToModel(task);
+            return JsonConvert.SerializeObject(taskModel, indentSubobjects ? Formatting.Indented : Formatting.None);
+        }
+
+        public static Models.Task TaskToModel(FuzzyLogicInference.Task task)
+        {
+            return new Models.Task {
                 name = task.Name,
                 in_vars = task.InputParameters.Select(ConvertParameterToModel).ToList(),
                 out_vars = task.OutputParameters.Select(ConvertParameterToModel).ToList(),
                 rules = task.Rules.Select(ConvertRuleToModel).ToList()
             };
-
-            return JsonConvert.SerializeObject(taskModel, indentSubobjects ? Formatting.Indented : Formatting.None);
         }
 
         public static IDictionary<FuzzyLogicInference.Parameter, double> InputsFromJson(FuzzyLogicInference.Task task, string json)
@@ -46,13 +54,35 @@ namespace Libraries.JsonParser
                 .ToDictionary(tuple => tuple.Item1, tuple => tuple.Item2);
         }
 
-        public static string SolutionToJson(IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> results) =>
-            SolutionToJson(results, true);
-
-        public static string SolutionToJson(IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> results, bool indented)
+        public static IDictionary<string, Models.OutputParameterSolution> SolutionToModel(
+            IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> solution,
+            double graphingStep)
         {
-            var dict = results.ToDictionary(r => r.Parameter.Name, r => r.GravityCenter);
-            return JsonConvert.SerializeObject(dict, indented ? Formatting.Indented : Formatting.None);
+            return solution.ToDictionary(
+                s => s.Parameter.Name,
+                s => new Models.OutputParameterSolution { gravity_center = s.GravityCenter, graph = BuildGraph(s, graphingStep) }
+            );
+        }
+
+        private static Models.OutputParameterSolution.Graph BuildGraph(
+            FuzzyLogicInference.Task.OutputParameterSolution oneVariableSolution,
+            double graphingStep)
+        {
+            var graphValues = oneVariableSolution.Parameter.Range
+                .EnumerateWithStep(graphingStep)
+                .Select(oneVariableSolution.ParameterDistribution)
+                .ToList();
+            
+            return new Models.OutputParameterSolution.Graph { values = graphValues, step = graphingStep };
+        }
+
+        public static string SolutionToJson(IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> results, double graphingStep) =>
+            SolutionToJson(results, graphingStep, true);
+
+        public static string SolutionToJson(IEnumerable<FuzzyLogicInference.Task.OutputParameterSolution> results, double graphingStep, bool indented)
+        {
+            var model = SolutionToModel(results, graphingStep);
+            return JsonConvert.SerializeObject(model, indented ? Formatting.Indented : Formatting.None);
         }
 
         private static FuzzyLogicInference.Parameter ConvertModelToParameter(Models.Parameter parameterModel)

--- a/src/Libraries/JsonParser/Models/OutputPatrameterSolution.cs
+++ b/src/Libraries/JsonParser/Models/OutputPatrameterSolution.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Libraries.JsonParser.Models
+{
+    public class OutputParameterSolution
+    {
+        public class Graph
+        {
+            public List<double> values { get; set; }
+            public double step { get; set; }
+        }
+        public Graph graph { get; set; }
+        public double gravity_center { get; set; }
+    }
+}

--- a/src/Libraries/JsonParser/Models/Parameter.cs
+++ b/src/Libraries/JsonParser/Models/Parameter.cs
@@ -12,5 +12,6 @@ namespace Libraries.JsonParser.Models
         public double from { get; set; }
         public double to { get; set; }
         public List<Class> classes { get; set; }
+        public double value { get; set; }
     }
 }


### PR DESCRIPTION
(Issue #25)

Now you can send a POST request with a task description in json format to **api/task/solve** gateway and aquire json with the task's solution.

The format for the task, sent to gateway, is the same as [decribed in docs](https://github.com/Jeanosis/IntelligentSystemsLabs/blob/feature/issue25/docs/json/task-format.md), except that each input parameter has a field `"value"` which contains its concrete floating-point value.

The output format is
```
{
    "out_var_name_1": {
        "gravity_center": <double value of the function gravity center>,
        "graph": {
            "values": [<about 300 values of the Y-axis>],
            "step": <double value of the graph's X-axis step>
        }
    },
    "out_var_name_2": { ... },
    ....
}
```